### PR TITLE
Add runtime selector dump utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 PDDebugKit is a Swift package that provides helper APIs for debugging.
 
-Currently it includes an API to return device and app information.
+Currently it includes an API to return device and app information and utilities for working with the Objective‑C runtime.
 
 ## Usage
 
 Add PDDebugKit as a dependency in your Swift Package manifest and import it in your code.
+
+### Listing selectors
+
+```swift
+let methodNames = dumpSelectors(of: MyClass.self, includingInherited: true)
+```
 
 ## License
 

--- a/Sources/PDDebugKit/RuntimeUtilities.swift
+++ b/Sources/PDDebugKit/RuntimeUtilities.swift
@@ -1,0 +1,24 @@
+import Foundation
+import ObjectiveC.runtime
+
+/// Returns an array of selector names for the given class.
+/// - Parameters:
+///   - cls: The class to inspect.
+///   - includingInherited: If `true`, include selectors from superclasses.
+/// - Returns: A list of selector names.
+public func dumpSelectors(of cls: AnyClass, includingInherited: Bool = false) -> [String] {
+    var selectors: [String] = []
+    var target: AnyClass? = cls
+    repeat {
+        var count: UInt32 = 0
+        if let list = class_copyMethodList(target, &count) {
+            defer { free(list) }
+            for i in 0..<Int(count) {
+                let sel = method_getName(list[i])
+                selectors.append(NSStringFromSelector(sel))
+            }
+        }
+        target = includingInherited ? class_getSuperclass(target) : nil
+    } while target != nil
+    return selectors
+}

--- a/Tests/PDDebugKitTests/RuntimeUtilitiesTests.swift
+++ b/Tests/PDDebugKitTests/RuntimeUtilitiesTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import PDDebugKit
+import Foundation
+
+private class SampleClass: NSObject {
+    @objc func exampleMethod() {}
+}
+
+@Test func dumpSelectorsReturnsMethods() async throws {
+    let methods = dumpSelectors(of: SampleClass.self)
+    #expect(methods.contains("exampleMethod"))
+}


### PR DESCRIPTION
## Summary
- add `dumpSelectors` utility for listing Objective-C selectors
- test the runtime selector dump
- document the new API

## Testing
- `swift test` *(fails: couldn't fetch DeviceKit dependency)*